### PR TITLE
Correctly avoid Cm_RedisSession override

### DIFF
--- a/app/code/community/SomethingDigital/SessionBackend/Model/Migrate.php
+++ b/app/code/community/SomethingDigital/SessionBackend/Model/Migrate.php
@@ -72,7 +72,7 @@ class SomethingDigital_SessionBackend_Model_Migrate extends SomethingDigital_Ses
         } elseif ($type === 'db') {
             // We specifically don't want a rewrite here - Cm_RedisSession uses one.
             $model = Mage::getResourceModel('core/session');
-            if (in_array('Cm_RedisSession_Model_Session', class_parents($model))) {
+            if (is_a($model, 'Cm_RedisSession_Model_Session')) {
                 return new Mage_Core_Model_Resource_Session();
             }
             return $model;

--- a/app/code/community/SomethingDigital/SessionBackend/etc/config.xml
+++ b/app/code/community/SomethingDigital/SessionBackend/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <SomethingDigital_SessionBackend>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </SomethingDigital_SessionBackend>
     </modules>
 


### PR DESCRIPTION
**:clock4: ConnectWise Code Review Ticket:** 334710

Of course, not everyone uses a subclass of Cm_RedisSession... still avoiding any attmpted autoload of `Cm_RedisSession_Model_Session` since if it doesn't exist, this may fail in Magento.